### PR TITLE
test: add nested node_modules test scenario

### DIFF
--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/.gitignore
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/gatsby-config.js
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/gatsby-config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [`gatsby-theme-child`],
+}

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/gatsby-config.js
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/gatsby-config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    `gatsby-theme-parent`,
+  ]
+}

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/gatsby-config.js
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/gatsby-config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    `gatsby-plugin-added-by-parent-theme`,
+  ]
+}

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/node_modules/gatsby-plugin-added-by-parent-theme/package.json
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/node_modules/gatsby-plugin-added-by-parent-theme/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "gatsby-plugin-added-by-parent-theme",
+  "main": "package.json",
+  "version": "0.0.1"
+}

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/package.json
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gatsby-theme-parent",
+  "main": "package.json",
+  "version": "0.0.1",
+  "dependencies": {
+    "gatsby-plugin-added-by-parent-theme": "^0.0.1"
+  }
+}

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/package.json
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gatsby-theme-child",
+  "main": "package.json",
+  "version": "0.0.1",
+  "dependencies": {
+    "gatsby-theme-parent": "^0.0.1"
+  }
+}

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/index.js
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/index.js
@@ -1,0 +1,95 @@
+const loadThemes = require(`..`)
+const path = require(`path`)
+
+describe(`loadThemes`, () => {
+  test(`resolves themes and plugins from location of gatsby-config`, async () => {
+    /*
+      Fixture used in this test is structured like this:
+
+      .
+      ├── gatsby-config.js
+      └── node_modules
+          └── gatsby-theme-child
+              ├── gatsby-config.js
+              ├── node_modules
+              │   └── gatsby-theme-parent
+              │       ├── gatsby-config.js
+              │       ├── node_modules
+              │       │   └── gatsby-plugin-added-by-parent-theme
+              │       │       └── package.json
+              │       └── package.json
+              └── package.json
+
+      This make sure we can handle cases when plugins and themes are not hoisted to root "node_modules", as well as simulates requirements for yarn PnP or pnpm
+      (being able to import modules only declared as dependencies of current package).
+    */
+
+    const configFilePath = require.resolve(
+      `./fixtures/resolve-from-config-location/gatsby-config`
+    )
+    const config = require(configFilePath)
+
+    const {
+      config: { plugins },
+      themes,
+    } = await loadThemes(config, {
+      useLegacyThemes: false,
+      configFilePath,
+      rootDir: path.dirname(configFilePath),
+    })
+
+    // implicit assertion - above doesn't throw `Couldn't find the "x" plugin`
+
+    expect(plugins.length).toEqual(3)
+
+    // all nested plugins / themes are found
+    expect(plugins).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resolve: `gatsby-theme-child`,
+        }),
+        expect.objectContaining({
+          resolve: `gatsby-theme-parent`,
+        }),
+        expect.objectContaining({
+          resolve: `gatsby-plugin-added-by-parent-theme`,
+        }),
+      ])
+    )
+
+    expect(themes.length).toEqual(3)
+
+    expect(themes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          themeName: `gatsby-theme-child`,
+          // `gatsby-theme-child` is resolved to first level node_modules
+          themeDir: path.dirname(
+            require.resolve(
+              `./fixtures/resolve-from-config-location/node_modules/gatsby-theme-child`
+            )
+          ),
+        }),
+        expect.objectContaining({
+          themeName: `gatsby-theme-parent`,
+          // `gatsby-theme-child` is resolved to second level node_modules
+          themeDir: path.dirname(
+            require.resolve(
+              `./fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent`
+            )
+          ),
+        }),
+
+        expect.objectContaining({
+          themeName: `gatsby-plugin-added-by-parent-theme`,
+          // `gatsby-theme-child` is resolved to third level node_modules
+          themeDir: path.dirname(
+            require.resolve(
+              `./fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/node_modules/gatsby-plugin-added-by-parent-theme`
+            )
+          ),
+        }),
+      ])
+    )
+  })
+})


### PR DESCRIPTION
This adds basic test for nested node_modules (including nested theme).

I decided against adding more tests in here, because your pull request ( https://github.com/gatsbyjs/gatsby/pull/23696 ) handles resolving part and not really plugin merging algo (other than omitting `parentDir`). I feel like it will be better to add more test scenarios/fixture in separate PRs in gatsby repo